### PR TITLE
CAC eam bug in force densities

### DIFF
--- a/src/pair_CAC_eam.cpp
+++ b/src/pair_CAC_eam.cpp
@@ -1068,6 +1068,14 @@ int distanceflag=0;
 	p = MIN(p, 1.0);
 	coeff = frho_spline[type2frho[origin_type]][m];
 	fp[0] = (coeff[0] * p + coeff[1])*p + coeff[2];
+
+	if (quad_eflag){
+		phi = ((coeff[3]*p + coeff[4])*p + coeff[5])*p + coeff[6];
+		if (rho[0] > rhomax) phi += fp[0] * (rho[0]-rhomax);
+ 		phi *= scale[origin_type][scan_type];
+  		quadrature_energy += phi;
+	}
+	
 	//compute derivative of the embedding energy for all atoms in the inner neighborlist
 	for (int l = 0; l < neigh_max_inner; l++) {
 


### PR DESCRIPTION
Adding back lines 1075-1080; required for correct eam energies. https://github.com/Adrian-Diaz/Temporary_CAC/commit/1748b7923d8b9058f530dd1308cd955d3624963f#diff-e0da59842818950e0da2a9102623e54eL1075
