### PR TITLE
fixed inclusion of null terminator in MPI_Bcast for read data functio…

### DIFF
--- a/src/pair_CAC.cpp
+++ b/src/pair_CAC.cpp
@@ -230,8 +230,10 @@ void PairCAC::compute(int eflag, int vflag) {
   numneigh = list->numneigh;
   firstneigh = list->firstneigh;
   reneighbor_time = neighbor->lastcall;
-	if (update->ntimestep == reneighbor_time||update->whichflag==2)
+	if (update->ntimestep == reneighbor_time||update->whichflag==2){
 	atom->neigh_weight_flag=1;
+	atom->weight_count=atom->nlocal;
+	}
   //quadrature warning
   /*
   if (warning_flag && !warned_flag) {
@@ -358,7 +360,6 @@ void PairCAC::compute(int eflag, int vflag) {
 	    neighbor_weights[i][0]=0;
 	    neighbor_weights[i][1]=0;
 	    neighbor_weights[i][2]=0;
-	    atom->weight_count=atom->nlocal;
 	    }
 			if (eflag) {
 				element_energy = 0;

--- a/src/pair_CAC_eam.cpp
+++ b/src/pair_CAC_eam.cpp
@@ -1010,7 +1010,7 @@ int distanceflag=0;
 
 
 		for (int k = 0; k < neigh_max_inner; k++) {
-
+      if(l==k) continue;
 			scan_type2 = inner_neighbor_types[k];
 			scan_position[0] = inner_neighbor_coords[k][0];
 			scan_position[1] = inner_neighbor_coords[k][1];

--- a/src/read_data.cpp
+++ b/src/read_data.cpp
@@ -1731,10 +1731,10 @@ void ReadData::CAC_elements()
 	int m, nchunk, nline, nlineinner, nmax, npoly, tmp, nodecount;
 
 	char *eof;
-	char *element_type = (char*)malloc(sizeof(char) * 20);
+	char *element_type = (char*)memory->smalloc(sizeof(char) * 20, "read_data: element type string");
 	int chunk = 20;
 	int mapflag = 0;
-	char *CAC_buffer = new char[chunk*MAXLINE*MAXELEMENT];
+	char *CAC_buffer = (char*)memory->smalloc(sizeof(char) *(chunk*MAXLINE*(MAXELEMENT+1)+1), "read_data: CAC_buffer");
 	//std::ofstream myfile;
 
 	// nmax = max # of bodies to read in this chunk
@@ -1783,7 +1783,7 @@ void ReadData::CAC_elements()
 					if (eof == NULL) error->one(FLERR, "Unexpected end of data file");
 
 					m += strlen(&CAC_buffer[m]);
-					if (nlineinner + 1 > MAXELEMENT)
+					if (nlineinner + 1 >= MAXELEMENT)
 						error->one(FLERR,
 							"Too many lines in one element in data file - increase MAXELEMENT in read_data.cpp");
 
@@ -1802,13 +1802,17 @@ void ReadData::CAC_elements()
 
 			}
 
-
+    if (m) {
+      if (CAC_buffer[m-1] != '\n') strcpy(&CAC_buffer[m++],"\n");
+      m++;
+    }
 
 		}
 
 
 		MPI_Bcast(&nchunk, 1, MPI_INT, 0, world);
 		MPI_Bcast(&m, 1, MPI_INT, 0, world);
+    
 		MPI_Bcast(CAC_buffer, m, MPI_CHAR, 0, world);
 
 
@@ -1845,8 +1849,8 @@ void ReadData::CAC_elements()
 		if (logfile) fprintf(logfile, "  " BIGINT_FORMAT " CAC_Elements\n", nCAC_elements);
 	}
 	*/
-	delete[] element_type;
-	delete[] CAC_buffer;
+	free (element_type);
+	free (CAC_buffer);
 }
 
 //----------------------------------------------------


### PR DESCRIPTION
…n, fixed an i-i loop inclusion error in the eam style density accumulation loop, and setting weight counts was moved up in the pair cac compute routine